### PR TITLE
[#1][Feat] News-To-Kafka-Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,232 @@
+# Created by https://www.toptal.com/developers/gitignore/api/gradle,macos,windows,intellij,java
+# Edit at https://www.toptal.com/developers/gitignore?templates=gradle,macos,windows,intellij,java
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+.idea/**
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+.idea/**/azureSettings.xml
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### Gradle ###
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+### Gradle Patch ###
+# Java heap dump
+*.hprof
+
+# End of https://www.toptal.com/developers/gitignore/api/gradle,macos,windows,intellij,java
+/.idea/compiler.xml
+/instargram-to-kafka-service/gradlew
+/instargram-to-kafka-service/gradlew.bat

--- a/news-to-kafka-service/.gitignore
+++ b/news-to-kafka-service/.gitignore
@@ -1,0 +1,41 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+gradlew
+gradlew.bat
+apllication.yml
+gradle/wrapper/**
+application.yml
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/

--- a/news-to-kafka-service/build.gradle
+++ b/news-to-kafka-service/build.gradle
@@ -1,0 +1,44 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.0.5'
+    id 'io.spring.dependency-management' version '1.1.0'
+}
+
+group = 'github.Jimoou'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '17'
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+    maven { url 'https://artifactory-oss.prod.netflix.net/artifactory/maven-oss-candidates' }
+}
+
+ext {
+    set('springCloudVersion', "2022.0.2")
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.json:json:20230227'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/news-to-kafka-service/settings.gradle
+++ b/news-to-kafka-service/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'news-to-kafka-service'

--- a/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/NewsToKafkaServiceApplication.java
+++ b/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/NewsToKafkaServiceApplication.java
@@ -1,0 +1,12 @@
+package github.Jimoou.newstokafkaservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class NewsToKafkaServiceApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(NewsToKafkaServiceApplication.class, args);
+  }
+}

--- a/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/client/AlphaVantageClient.java
+++ b/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/client/AlphaVantageClient.java
@@ -1,0 +1,16 @@
+package github.Jimoou.newstokafkaservice.client;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@AllArgsConstructor
+public class AlphaVantageClient {
+  private RestTemplate restTemplate;
+  public String getNewsAndSentiments(String topic, int limit, String apiKey) {
+    String url = String.format("https://www.alphavantage.co/query?function=NEWS_SENTIMENT&topics=%s&limit=%d&apikey=%s", topic, limit,apiKey);
+    String json = restTemplate.getForObject(url, String.class);
+    return json;
+  }
+}

--- a/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/config/ConfigData.java
+++ b/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/config/ConfigData.java
@@ -1,0 +1,15 @@
+package github.Jimoou.newstokafkaservice.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "news-to-kafka-service")
+public class ConfigData {
+    private List<String> topics;
+    private String key;
+}

--- a/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/config/RestTemplateConfig.java
+++ b/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package github.Jimoou.newstokafkaservice.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/controller/NewsController.java
+++ b/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/controller/NewsController.java
@@ -1,0 +1,24 @@
+package github.Jimoou.newstokafkaservice.controller;
+
+import github.Jimoou.newstokafkaservice.model.News;
+import github.Jimoou.newstokafkaservice.service.NewsService;
+import lombok.AllArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+public class NewsController {
+    private NewsService newsService;
+
+    @GetMapping("/news")
+    public ResponseEntity<List<News>> getNews() {
+        List<News> newsList = newsService.getTopNews();
+        return new ResponseEntity<>(newsList, HttpStatus.OK);
+    }
+}

--- a/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/model/News.java
+++ b/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/model/News.java
@@ -1,0 +1,17 @@
+package github.Jimoou.newstokafkaservice.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class News {
+    private String title;
+    private String url;
+    private String summary;
+    private String publishedAt;
+}

--- a/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/service/NewsService.java
+++ b/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/service/NewsService.java
@@ -1,0 +1,8 @@
+package github.Jimoou.newstokafkaservice.service;
+
+import github.Jimoou.newstokafkaservice.model.News;
+import java.util.List;
+
+public interface NewsService {
+    List<News> getTopNews();
+}

--- a/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/service/implement/NewsServiceImpl.java
+++ b/news-to-kafka-service/src/main/java/github/Jimoou/newstokafkaservice/service/implement/NewsServiceImpl.java
@@ -1,0 +1,46 @@
+package github.Jimoou.newstokafkaservice.service.implement;
+
+import github.Jimoou.newstokafkaservice.client.AlphaVantageClient;
+import github.Jimoou.newstokafkaservice.config.ConfigData;
+import github.Jimoou.newstokafkaservice.model.News;
+import github.Jimoou.newstokafkaservice.service.NewsService;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class NewsServiceImpl implements NewsService {
+  private final AlphaVantageClient alphaVantageClient;
+  private final ConfigData configData;
+
+  @Override
+  public List<News> getTopNews() {
+    List<String> topics = configData.getTopics();
+    String API_KEY = configData.getKey();
+
+    List<News> topNews = new ArrayList<>();
+
+    for (String topic : topics) {
+      String json = alphaVantageClient.getNewsAndSentiments(topic, 2, API_KEY);
+      JSONObject jsonObject = new JSONObject(json);
+      JSONArray feed = jsonObject.getJSONArray("feed");
+
+      IntStream.range(0, feed.length()).mapToObj(feed::getJSONObject).forEach(newsObject -> {
+        News news = new News();
+        news.setTitle(newsObject.getString("title"));
+        news.setUrl(newsObject.getString("url"));
+        news.setSummary(newsObject.getString("summary"));
+        news.setPublishedAt(newsObject.getString("time_published"));
+        topNews.add(news);
+      });
+    }
+    return topNews;
+  }
+}

--- a/news-to-kafka-service/src/test/java/github/Jimoou/newstokafkaservice/NewsToKafkaServiceApplicationTests.java
+++ b/news-to-kafka-service/src/test/java/github/Jimoou/newstokafkaservice/NewsToKafkaServiceApplicationTests.java
@@ -1,0 +1,13 @@
+package github.Jimoou.newstokafkaservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class NewsToKafkaServiceApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
1. config
- `ConfigData` : appication.yml 파일을 이용하여, Topics와 API_KEY를 설정해줌.
- `RestTemplateConfig` : Alpha Vantage API 요청을 보낼 RestTemplate의 빈을 생성해주는 설정파일
2. `client`
- `AlphaVantageClient` : `RestTemplate`을 이용하여 `Alpha Vantage API` 중 `NewsAndSentiments` 요청을 하는 service 클래스
3. controller
- `NewsController` : Postman을 이용하여 테스트 하기 위해 임시로 만들어 놓은 API Endpoint
4. model
- `News` : 뉴스의 타이틀, 요약, 링크, 작성일을 매핑해줄 모델클래스
5. service
- `NewsService`: 서비스의 인터페이스
- `NewsServiceImpl` : 서비스의 로직을 처리하는 클래스
  - getTopNews : 설정된 토픽리스트로 검색된 뉴스의 최신 기사 2개씩을 가져와서 반환하는 메소드

6. 프로젝트 의존성
 - Eureka Client
 - JSON In Java
 - lombok
 - spring web